### PR TITLE
Add Zacapu Escucha starter skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Zacapu Escucha
+
+A minimal modular system for collecting citizen reports.
+
+## Structure
+- `public/` React + Tailwind form
+- `admin/` basic admin pages
+- `api/` PHP endpoints
+- `includes/` configuration and auth
+- `bot/` Telegram webhook handler
+- `assets/` styles
+
+## Setup
+1. Configure database credentials in `includes/config.php`.
+2. Deploy files on a PHP-enabled server (cPanel compatible).
+3. Set a Telegram bot webhook to `bot/webhook.php`.
+
+This is a simplified starter implementation.

--- a/admin/dashboard.js
+++ b/admin/dashboard.js
@@ -1,0 +1,10 @@
+fetch('/api/list_reports.php')
+  .then(res => res.json())
+  .then(data => {
+    const reports = document.getElementById('reports');
+    data.forEach(r => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td class='border px-2'>${r.folio}</td><td class='border px-2'>${r.type}</td><td class='border px-2'>${r.status}</td>`;
+      reports.appendChild(tr);
+    });
+  });

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,21 @@
+<?php include '../includes/auth.php'; ?>
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Admin Dashboard</title>
+  <link rel="stylesheet" href="../assets/style.css">
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4">
+  <h1 class="text-2xl mb-4">Dashboard</h1>
+  <div id="stats" class="grid grid-cols-3 gap-4 mb-4"></div>
+  <table class="min-w-full border">
+    <thead><tr><th class="border px-2">Folio</th><th class="border px-2">Type</th><th class="border px-2">Status</th></tr></thead>
+    <tbody id="reports"></tbody>
+  </table>
+
+<script src="dashboard.js"></script>
+</body>
+</html>

--- a/admin/login.html
+++ b/admin/login.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Admin Login</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 flex items-center justify-center h-screen">
+  <form action="/api/login.php" method="post" class="bg-white p-6 shadow rounded">
+    <h1 class="text-xl mb-4">Login</h1>
+    <input type="text" name="user" placeholder="User" class="border p-2 w-full mb-4">
+    <input type="password" name="pass" placeholder="Password" class="border p-2 w-full mb-4">
+    <button class="bg-burgundy text-white px-4 py-2 w-full">Login</button>
+  </form>
+</body>
+</html>

--- a/api/list_reports.php
+++ b/api/list_reports.php
@@ -1,0 +1,12 @@
+<?php
+require '../includes/config.php';
+header('Content-Type: application/json');
+
+$result = $mysqli->query('SELECT folio, type, status FROM reports ORDER BY id DESC');
+$rows = [];
+while ($row = $result->fetch_assoc()) {
+    $rows[] = $row;
+}
+
+echo json_encode($rows);
+?>

--- a/api/login.php
+++ b/api/login.php
@@ -1,0 +1,15 @@
+<?php
+require '../includes/config.php';
+session_start();
+
+$user = $_POST['user'] ?? '';
+$pass = $_POST['pass'] ?? '';
+
+// dummy credentials
+if ($user === 'admin' && $pass === 'secret') {
+    $_SESSION['user_id'] = 1;
+    header('Location: /admin/index.html');
+} else {
+    echo 'Invalid';
+}
+?>

--- a/api/report.php
+++ b/api/report.php
@@ -1,0 +1,35 @@
+<?php
+require '../includes/config.php';
+
+header('Content-Type: application/json');
+
+$type = $_POST['type'] ?? '';
+$anonymous = isset($_POST['anonymous']);
+$name = $anonymous ? '' : $_POST['name'] ?? '';
+$contact = $anonymous ? '' : $_POST['contact'] ?? '';
+$description = $_POST['description'] ?? '';
+
+if (!$type || !$description) {
+    echo json_encode(['success' => false, 'error' => 'Missing fields']);
+    exit;
+}
+
+$folio = 'ZC-' . str_pad(random_int(1, 999999), 6, '0', STR_PAD_LEFT);
+
+$mysqli->prepare('CREATE TABLE IF NOT EXISTS reports (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    folio VARCHAR(20),
+    type VARCHAR(50),
+    name VARCHAR(100),
+    contact VARCHAR(100),
+    description TEXT,
+    status VARCHAR(20) DEFAULT "Pending",
+    created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)')->execute();
+
+$stmt = $mysqli->prepare('INSERT INTO reports (folio, type, name, contact, description) VALUES (?, ?, ?, ?, ?)');
+$stmt->bind_param('sssss', $folio, $type, $name, $contact, $description);
+$stmt->execute();
+
+echo json_encode(['success' => true, 'folio' => $folio]);
+?>

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,2 @@
+.text-burgundy { color: #800020; }
+.bg-burgundy { background-color: #800020; }

--- a/bot/webhook.php
+++ b/bot/webhook.php
@@ -1,0 +1,24 @@
+<?php
+require '../includes/config.php';
+$content = file_get_contents('php://input');
+$update = json_decode($content, true);
+
+if (!isset($update['message'])) {
+    exit;
+}
+
+$message = $update['message'];
+$text = $message['text'] ?? '';
+$chat_id = $message['chat']['id'];
+
+if (stripos($text, 'Attended') === 0) {
+    // parse folio from message
+    $parts = explode(' ', $text);
+    $folio = $parts[1] ?? '';
+    if ($folio) {
+        $stmt = $mysqli->prepare('UPDATE reports SET status="Attended" WHERE folio=?');
+        $stmt->bind_param('s', $folio);
+        $stmt->execute();
+    }
+}
+?>

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -1,0 +1,7 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /admin/login.html');
+    exit;
+}
+?>

--- a/includes/config.php
+++ b/includes/config.php
@@ -1,0 +1,11 @@
+<?php
+$DB_HOST = 'localhost';
+$DB_USER = 'username';
+$DB_PASS = 'password';
+$DB_NAME = 'zacapu';
+
+$mysqli = new mysqli($DB_HOST, $DB_USER, $DB_PASS, $DB_NAME);
+if ($mysqli->connect_errno) {
+    die('Connect Error: ' . $mysqli->connect_error);
+}
+?>

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,41 @@
+const { useState } = React;
+
+function ReportForm() {
+  const [status, setStatus] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const formData = new FormData(e.target);
+    const res = await fetch('/api/report.php', { method: 'POST', body: formData });
+    const data = await res.json();
+    if (data.success) {
+      setStatus('Report submitted. Your folio: ' + data.folio);
+    } else {
+      setStatus('Error: ' + data.error);
+    }
+  };
+
+  return (
+    React.createElement('form', { onSubmit: handleSubmit, className: 'p-4 max-w-lg mx-auto' },
+      React.createElement('h1', { className: 'text-2xl mb-4 text-center text-burgundy' }, 'Zacapu Escucha'),
+      React.createElement('label', { className: 'block mb-2' }, 'Report Type'),
+      React.createElement('select', { name: 'type', className: 'border p-2 w-full mb-4' },
+        ['Complaint','Suggestion','Citizen Report','Police Report','Corruption Report','Trash Issue','Water Leak'].map(t =>
+          React.createElement('option', { key: t }, t)
+        )
+      ),
+      React.createElement('label', { className: 'block mb-2' },
+        React.createElement('input', { type: 'checkbox', name: 'anonymous', className: 'mr-2' }),
+        'Anonymous'
+      ),
+      React.createElement('input', { type: 'text', name: 'name', placeholder: 'Full name', className: 'border p-2 w-full mb-4' }),
+      React.createElement('input', { type: 'text', name: 'contact', placeholder: 'Phone or email', className: 'border p-2 w-full mb-4' }),
+      React.createElement('textarea', { name: 'description', placeholder: 'Description', className: 'border p-2 w-full mb-4' }),
+      React.createElement('input', { type: 'file', name: 'file', className: 'mb-4' }),
+      React.createElement('button', { type: 'submit', className: 'bg-burgundy text-white px-4 py-2' }, 'Submit'),
+      status && React.createElement('p', { className: 'mt-4' }, status)
+    )
+  );
+}
+
+ReactDOM.render(React.createElement(ReportForm), document.getElementById('root'));

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Zacapu Escucha</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+</head>
+<body class="bg-white text-gray-800">
+  <div id="root"></div>
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- set up folder structure for public report form and admin panel
- add React+Tailwind form with basic fields
- implement PHP endpoints for report submission and list retrieval
- add minimal admin pages and Telegram webhook handler
- document setup instructions

## Testing
- `node -v`
- `php -l` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686dc0a607e0832dae7a943b6bec4643